### PR TITLE
Refine professional copy across site pages

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,8 +1,22 @@
 ---
 title: "About"
 permalink: /about/
-header: 
+header:
     image: "/images/waterfront.jpg"
 ---
-I am a data scientist who excels at exploratory data analysis, machine learning, and data visualizations. Lets make data great again :)
 
+I’m Hossein Hosseini, a data scientist focused on building trustworthy analytics and machine learning solutions. My background spans exploratory analysis, predictive modeling, and crafting visual narratives that help teams act on evidence.
+
+### What I bring
+- Translating messy data into decision-ready metrics, dashboards, and recommendations.
+- Designing experiments and model evaluations that stand up to scrutiny.
+- Communicating results clearly to both technical and executive audiences.
+
+### Recent focus
+Delivering projects end-to-end: ingesting and cleaning data, building models, and launching stakeholder-ready dashboards. I’m at my best collaborating across product, engineering, and business teams to ensure insights map to measurable outcomes.
+
+### Outside of work
+When I’m not working with data, you can find me exploring the Toronto food scene or reading about human-centered AI.
+
+### Let’s connect
+If you’d like to discuss a project or simply connect, reach me at h_hosseini@hotmail.com or on [LinkedIn](https://linkedin.com/in/hossein-h-4b18a82a/).

--- a/_pages/datascience.md
+++ b/_pages/datascience.md
@@ -1,12 +1,14 @@
 ---
 layout: archive
 permalink: /datascience/
-title: "Data Scence Posts by Tags"
+title: "Data Science Posts by Tag"
 author_profile: true
-
-header: 
+header:
     image: "/images/waterfront.jpg"
 ---
+
+Browse data science articles organized by topic. Each tag groups projects and write-ups so you can quickly find work relevant to your interests, from analytics deep dives to machine learning builds.
+
 {% include group-by-array collection=site.posts field="tags" %}
 
 {% for tag in group_names %}

--- a/index.html
+++ b/index.html
@@ -4,3 +4,22 @@ author_profile: true
 header:
     image: "/images/waterfront.jpg"
 ---
+
+<section class="page__content">
+
+### Welcome
+I help teams translate complex data into clear, defensible decisions. My work spans exploratory analysis, applied machine learning, and executive-ready storytelling that keeps projects moving with confidence.
+
+### Services
+- **Analytics & Experimentation:** Design rigorous analyses, A/B tests, and dashboards that keep product, marketing, and engineering aligned.
+- **Machine Learning Delivery:** Ship end-to-end pipelines, from feature engineering and model evaluation through to deployment and monitoring.
+- **Data Communication:** Convert findings into concise narratives and visuals tailored for both technical and leadership audiences.
+
+### Explore
+- Browse the latest posts below, or visit the [Data Science archive](/datascience/) to jump to topics of interest.
+- Learn more about my background on the [About](/about/) page, including ways to connect.
+
+### Availability
+Open to collaborations, consulting engagements, and speaking on data strategy or applied ML. Let’s partner to make your data work for the goals that matter.
+
+</section>


### PR DESCRIPTION
## Summary
- update the home page messaging with clearer service positioning and availability note
- reorganize the About page with capability highlights, recent focus, and contact details
- polish the Data Science archive introduction to describe the topics covered

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable missing because bundle install cannot fetch gems in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ac0996a0832db44dd882e4c98898)